### PR TITLE
Add Supabase authentication system

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,0 +1,110 @@
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import Link from 'next/link';
+import { useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import { useRouter } from 'next/navigation';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+  remember: z.boolean().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function LoginPage() {
+  const supabase = createSupabaseBrowserClient();
+  const router = useRouter();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(schema), defaultValues: { remember: true } });
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const onSubmit = async (data: FormData) => {
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithPassword({
+      email: data.email,
+      password: data.password,
+    });
+    if (error) {
+      setMessage(error.message);
+    } else {
+      router.push('/');
+    }
+    setLoading(false);
+  };
+
+  const oauthLogin = async (provider: 'google' | 'azure') => {
+    await supabase.auth.signInWithOAuth({ provider });
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Login</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label className="block mb-1">Email</label>
+          <input
+            type="email"
+            className="w-full border p-2 rounded"
+            {...register('email')}
+          />
+          {errors.email && (
+            <p className="text-red-500 text-sm">{errors.email.message}</p>
+          )}
+        </div>
+        <div>
+          <label className="block mb-1">Password</label>
+          <input
+            type="password"
+            className="w-full border p-2 rounded"
+            {...register('password')}
+          />
+          {errors.password && (
+            <p className="text-red-500 text-sm">{errors.password.message}</p>
+          )}
+        </div>
+        <div className="flex items-center">
+          <input type="checkbox" className="mr-2" {...register('remember')} />
+          <label>Remember me</label>
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-primary text-white py-2 rounded"
+        >
+          {loading ? 'Loading...' : 'Login'}
+        </button>
+        {message && <p className="text-sm mt-2">{message}</p>}
+      </form>
+      <div className="mt-4 space-y-2">
+        <button
+          onClick={() => oauthLogin('google')}
+          className="w-full border p-2 rounded"
+        >
+          Login with Google
+        </button>
+        <button
+          onClick={() => oauthLogin('azure')}
+          className="w-full border p-2 rounded"
+        >
+          Login with Microsoft
+        </button>
+      </div>
+      <div className="mt-4 text-sm flex justify-between">
+        <Link href="/auth/reset/request" className="text-primary hover:underline">
+          Forgot password?
+        </Link>
+        <Link href="/auth/signup" className="text-primary hover:underline">
+          Sign up
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/auth/reset/page.tsx
+++ b/app/auth/reset/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+
+const schema = z.object({ password: z.string().min(6) });
+
+export default function ResetPasswordPage() {
+  const supabase = createSupabaseBrowserClient();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<{ password: string }>({ resolver: zodResolver(schema) });
+  const [loading, setLoading] = useState(true);
+  const [message, setMessage] = useState('');
+  const [tokenVerified, setTokenVerified] = useState(false);
+
+  useEffect(() => {
+    const code = searchParams.get('code') || searchParams.get('token');
+    if (!code) {
+      setLoading(false);
+      setMessage('Invalid token');
+      return;
+    }
+    supabase.auth
+      .exchangeCodeForSession(code)
+      .then(({ error }) => {
+        if (error) {
+          setMessage(error.message);
+        } else {
+          setTokenVerified(true);
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [searchParams, supabase]);
+
+  const onSubmit = async ({ password }: { password: string }) => {
+    setLoading(true);
+    const { error } = await supabase.auth.updateUser({ password });
+    if (error) setMessage(error.message);
+    else {
+      setMessage('Password updated.');
+      router.push('/auth/login');
+    }
+    setLoading(false);
+  };
+
+  if (loading) {
+    return <p className="p-4">Loading...</p>;
+  }
+
+  if (!tokenVerified) {
+    return <p className="p-4 text-red-500">{message}</p>;
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Set New Password</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label className="block mb-1">New Password</label>
+          <input
+            type="password"
+            className="w-full border p-2 rounded"
+            {...register('password')}
+          />
+          {errors.password && (
+            <p className="text-red-500 text-sm">{errors.password.message}</p>
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-primary text-white py-2 rounded"
+        >
+          {loading ? 'Saving...' : 'Update Password'}
+        </button>
+        {message && <p className="text-sm mt-2">{message}</p>}
+      </form>
+    </div>
+  );
+}

--- a/app/auth/reset/request/page.tsx
+++ b/app/auth/reset/request/page.tsx
@@ -1,0 +1,60 @@
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { useState } from 'react';
+import Link from 'next/link';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+
+const schema = z.object({ email: z.string().email() });
+
+export default function RequestResetPage() {
+  const supabase = createSupabaseBrowserClient();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<{ email: string }>({ resolver: zodResolver(schema) });
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const onSubmit = async ({ email }: { email: string }) => {
+    setLoading(true);
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${location.origin}/auth/reset`,
+    });
+    if (error) setMessage(error.message);
+    else setMessage('Check your email for a password reset link.');
+    setLoading(false);
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Reset Password</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label className="block mb-1">Email</label>
+          <input
+            type="email"
+            className="w-full border p-2 rounded"
+            {...register('email')}
+          />
+          {errors.email && (
+            <p className="text-red-500 text-sm">{errors.email.message}</p>
+          )}
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-primary text-white py-2 rounded"
+        >
+          {loading ? 'Loading...' : 'Send reset link'}
+        </button>
+        {message && <p className="text-sm mt-2">{message}</p>}
+      </form>
+      <p className="mt-4 text-sm">
+        Remembered? <Link href="/auth/login">Login</Link>
+      </p>
+    </div>
+  );
+}

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+
+const schema = z
+  .object({
+    email: z.string().email(),
+    password: z.string().min(6),
+    company: z.string().min(1),
+    terms: z.literal(true, {
+      errorMap: () => ({ message: 'You must accept the terms' }),
+    }),
+  })
+  .required();
+
+type FormData = z.infer<typeof schema>;
+
+export default function SignupPage() {
+  const supabase = createSupabaseBrowserClient();
+  const router = useRouter();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const onSubmit = async (data: FormData) => {
+    setLoading(true);
+    const { error } = await supabase.auth.signUp({
+      email: data.email,
+      password: data.password,
+      options: { data: { company: data.company } },
+    });
+    if (error) {
+      setMessage(error.message);
+    } else {
+      setMessage('Check your email to verify your account.');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Sign Up</h1>
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <div>
+          <label className="block mb-1">Email</label>
+          <input
+            type="email"
+            className="w-full border p-2 rounded"
+            {...register('email')}
+          />
+          {errors.email && (
+            <p className="text-red-500 text-sm">{errors.email.message}</p>
+          )}
+        </div>
+        <div>
+          <label className="block mb-1">Password</label>
+          <input
+            type="password"
+            className="w-full border p-2 rounded"
+            {...register('password')}
+          />
+          {errors.password && (
+            <p className="text-red-500 text-sm">{errors.password.message}</p>
+          )}
+        </div>
+        <div>
+          <label className="block mb-1">Company Name</label>
+          <input
+            type="text"
+            className="w-full border p-2 rounded"
+            {...register('company')}
+          />
+          {errors.company && (
+            <p className="text-red-500 text-sm">{errors.company.message}</p>
+          )}
+        </div>
+        <div className="flex items-center">
+          <input type="checkbox" className="mr-2" {...register('terms')} />
+          <label>I agree to the Terms of Service</label>
+        </div>
+        {errors.terms && (
+          <p className="text-red-500 text-sm">{errors.terms.message}</p>
+        )}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-primary text-white py-2 rounded"
+        >
+          {loading ? 'Loading...' : 'Sign Up'}
+        </button>
+        {message && <p className="text-sm mt-2">{message}</p>}
+      </form>
+      <p className="mt-4 text-sm">
+        Already have an account? <Link href="/auth/login">Login</Link>
+      </p>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { UserProvider } from "@/components/user-context";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <UserProvider>{children}</UserProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,22 @@
 import Image from "next/image";
+import Link from "next/link";
+import { useUser } from "@/components/user-context";
 
 export default function Home() {
+  const { user, signOut } = useUser();
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+      <header className="self-start w-full flex justify-end">
+        {user ? (
+          <button onClick={signOut} className="text-sm underline">
+            Sign out
+          </button>
+        ) : (
+          <Link href="/auth/login" className="text-sm underline">
+            Login
+          </Link>
+        )}
+      </header>
       <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
         <Image
           className="dark:invert"

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { useState } from 'react';
+import { useUser } from '@/components/user-context';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+
+const profileSchema = z.object({ fullName: z.string().min(1) });
+const passwordSchema = z.object({ password: z.string().min(6) });
+
+export default function SettingsPage() {
+  const { user } = useUser();
+  const supabase = createSupabaseBrowserClient();
+  const profileForm = useForm<{ fullName: string }>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: { fullName: user?.user_metadata.fullName || '' },
+  });
+  const passwordForm = useForm<{ password: string }>({
+    resolver: zodResolver(passwordSchema),
+  });
+  const [message, setMessage] = useState('');
+
+  const updateProfile = async ({ fullName }: { fullName: string }) => {
+    const { error } = await supabase.auth.updateUser({ data: { fullName } });
+    if (error) setMessage(error.message);
+    else setMessage('Profile updated');
+  };
+
+  const changePassword = async ({ password }: { password: string }) => {
+    const { error } = await supabase.auth.updateUser({ password });
+    if (error) setMessage(error.message);
+    else setMessage('Password changed');
+  };
+
+  if (!user) return <p className="p-4">Loading...</p>;
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-8">
+      <h1 className="text-2xl font-bold">Settings</h1>
+      <section>
+        <h2 className="font-semibold mb-2">Profile</h2>
+        <form
+          onSubmit={profileForm.handleSubmit(updateProfile)}
+          className="space-y-4"
+        >
+          <div>
+            <label className="block mb-1">Full Name</label>
+            <input
+              className="w-full border p-2 rounded"
+              {...profileForm.register('fullName')}
+            />
+            {profileForm.formState.errors.fullName && (
+              <p className="text-red-500 text-sm">
+                {profileForm.formState.errors.fullName.message}
+              </p>
+            )}
+          </div>
+          <button type="submit" className="bg-primary text-white py-2 px-4 rounded">
+            Save
+          </button>
+        </form>
+      </section>
+      <section>
+        <h2 className="font-semibold mb-2">Change Password</h2>
+        <form
+          onSubmit={passwordForm.handleSubmit(changePassword)}
+          className="space-y-4"
+        >
+          <div>
+            <label className="block mb-1">New Password</label>
+            <input
+              type="password"
+              className="w-full border p-2 rounded"
+              {...passwordForm.register('password')}
+            />
+            {passwordForm.formState.errors.password && (
+              <p className="text-red-500 text-sm">
+                {passwordForm.formState.errors.password.message}
+              </p>
+            )}
+          </div>
+          <button type="submit" className="bg-primary text-white py-2 px-4 rounded">
+            Update Password
+          </button>
+        </form>
+      </section>
+      {message && <p className="text-sm">{message}</p>}
+    </div>
+  );
+}

--- a/components/user-context.tsx
+++ b/components/user-context.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { Session, User } from '@supabase/supabase-js';
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+
+interface UserContextState {
+  user: User | null;
+  session: Session | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+const UserContext = createContext<UserContextState | undefined>(undefined);
+
+export const UserProvider = ({ children }: { children: React.ReactNode }) => {
+  const supabase = createSupabaseBrowserClient();
+  const [session, setSession] = useState<Session | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = async () => {
+    const {
+      data: { session: current },
+    } = await supabase.auth.getSession();
+    setSession(current);
+    setUser(current?.user ?? null);
+  };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+    await refresh();
+  };
+
+  useEffect(() => {
+    refresh().finally(() => setLoading(false));
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(() => {
+      refresh();
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  return (
+    <UserContext.Provider value={{ user, session, loading, refresh, signOut }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export const useUser = () => {
+  const ctx = useContext(UserContext);
+  if (!ctx) throw new Error('useUser must be used within UserProvider');
+  return ctx;
+};

--- a/lib/supabase-browser.ts
+++ b/lib/supabase-browser.ts
@@ -1,0 +1,7 @@
+import { createBrowserClient } from '@supabase/auth-helpers-nextjs';
+
+export const createSupabaseBrowserClient = () =>
+  createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -1,0 +1,9 @@
+import { cookies } from 'next/headers';
+import { createServerClient } from '@supabase/auth-helpers-nextjs';
+
+export const createSupabaseServerClient = () =>
+  createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies }
+  );

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs';
+
+export async function middleware(req: NextRequest) {
+  const res = NextResponse.next();
+  const supabase = createMiddlewareClient({ req, res });
+  await supabase.auth.getSession();
+
+  const { pathname } = req.nextUrl;
+  const isAuthRoute = pathname.startsWith('/auth');
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session && !isAuthRoute && pathname.startsWith('/settings')) {
+    return NextResponse.redirect(new URL('/auth/login', req.url));
+  }
+  return res;
+}
+
+export const config = {
+  matcher: ['/settings/:path*'],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.56.0",
@@ -39,6 +40,6 @@
     "eslint-config-next": "15.3.5",
     "prisma": "^6.11.1",
     "tailwindcss": "^4",
-    "typescript": "^5"
-  }
-}
+    "typescript": "^5",
+    "vitest": "^1.5.0"
+  }}

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,33 @@
+import { expect, it, describe } from 'vitest';
+import * as z from 'zod';
+
+const schema = z
+  .object({
+    email: z.string().email(),
+    password: z.string().min(6),
+    company: z.string().min(1),
+    terms: z.literal(true),
+  })
+  .required();
+
+describe('signup schema', () => {
+  it('fails when email invalid', () => {
+    const result = schema.safeParse({
+      email: 'bad',
+      password: '123456',
+      company: 'Acme',
+      terms: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('passes with valid data', () => {
+    const result = schema.safeParse({
+      email: 'test@example.com',
+      password: '123456',
+      company: 'Acme',
+      terms: true,
+    });
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- integrate Supabase clients
- provide user context provider
- add sign up, login, and password reset pages
- add settings page
- add middleware to protect routes
- update root layout and home page
- add basic validation tests

## Testing
- `npm run lint` *(fails: requires interactive config)*
- `npm run test` *(fails: PostCSS plugin error)*

------
https://chatgpt.com/codex/tasks/task_e_686d5f038fcc8329a528698dfd0cf7d9