### PR TITLE
Implement competitor monitoring skeleton

### DIFF
--- a/app/api/competitors/[id]/changes/route.ts
+++ b/app/api/competitors/[id]/changes/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  // placeholder - would fetch change history from DB
+  return NextResponse.json({ changes: [] });
+}
+

--- a/app/api/competitors/[id]/snapshots/route.ts
+++ b/app/api/competitors/[id]/snapshots/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  // placeholder - would fetch snapshots from DB
+  return NextResponse.json({ snapshots: [] });
+}
+

--- a/app/api/competitors/route.ts
+++ b/app/api/competitors/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    if (!data.name || !data.website) {
+      return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+    // placeholder - would save to DB
+    return NextResponse.json({ message: 'Competitor added' });
+  } catch {
+    return NextResponse.json({ error: 'Failed to add competitor' }, { status: 500 });
+  }
+}
+

--- a/app/api/competitors/settings/route.ts
+++ b/app/api/competitors/settings/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET() {
+  // placeholder - would get settings from DB
+  return NextResponse.json({ settings: {} });
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const data = await req.json();
+    // placeholder - would update settings
+    return NextResponse.json({ message: 'Settings updated', data });
+  } catch {
+    return NextResponse.json({ error: 'Failed to update settings' }, { status: 500 });
+  }
+}
+

--- a/app/dashboard/competitors/page.tsx
+++ b/app/dashboard/competitors/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { Plus } from 'lucide-react';
 import { Modal } from '@/components/ui/Modal';
+import { CompetitorDashboard } from '@/components/ui/CompetitorDashboard';
 
 interface Competitor {
   id: number;
@@ -35,6 +36,7 @@ export default function CompetitorsPage() {
       <Modal title="Add Competitor" open={open} onOpenChange={setOpen}>
         <p className="text-sm">Add competitor form placeholder.</p>
       </Modal>
+      <CompetitorDashboard />
     </div>
   );
 }

--- a/components/ui/AlertPreferences.tsx
+++ b/components/ui/AlertPreferences.tsx
@@ -1,0 +1,22 @@
+'use client';
+import React from 'react';
+
+interface Props {
+  enabled: boolean;
+  onChange(enabled: boolean): void;
+}
+
+export function AlertPreferences({ enabled, onChange }: Props) {
+  return (
+    <label className="flex items-center gap-2">
+      <input
+        type="checkbox"
+        checked={enabled}
+        onChange={(e) => onChange(e.target.checked)}
+        className="form-checkbox"
+      />
+      Receive alerts
+    </label>
+  );
+}
+

--- a/components/ui/ChangeDiffViewer.tsx
+++ b/components/ui/ChangeDiffViewer.tsx
@@ -1,0 +1,32 @@
+'use client';
+import React from 'react';
+
+interface Diff {
+  field: string;
+  before: string;
+  after: string;
+}
+
+export function ChangeDiffViewer({ diffs }: { diffs: Diff[] }) {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr>
+          <th className="text-left">Field</th>
+          <th className="text-left">Before</th>
+          <th className="text-left">After</th>
+        </tr>
+      </thead>
+      <tbody>
+        {diffs.map((d) => (
+          <tr key={d.field} className="border-t">
+            <td>{d.field}</td>
+            <td className="text-gray-500">{d.before}</td>
+            <td className="text-green-600">{d.after}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+

--- a/components/ui/CompetitorDashboard.tsx
+++ b/components/ui/CompetitorDashboard.tsx
@@ -1,0 +1,16 @@
+'use client';
+import React from 'react';
+import { CompetitorTimeline } from './CompetitorTimeline';
+
+export function CompetitorDashboard() {
+  const items = [
+    { date: '2024-01-01', description: 'Initial snapshot captured' },
+  ];
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Competitor Insights</h2>
+      <CompetitorTimeline items={items} />
+    </div>
+  );
+}
+

--- a/components/ui/CompetitorTimeline.tsx
+++ b/components/ui/CompetitorTimeline.tsx
@@ -1,0 +1,21 @@
+'use client';
+import React from 'react';
+
+interface TimelineItem {
+  date: string;
+  description: string;
+}
+
+export function CompetitorTimeline({ items }: { items: TimelineItem[] }) {
+  return (
+    <ul className="space-y-2">
+      {items.map((item) => (
+        <li key={item.date} className="bg-white dark:bg-gray-800 p-2 rounded shadow">
+          <div className="text-sm text-gray-500">{item.date}</div>
+          <div>{item.description}</div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/services/competitorCron.ts
+++ b/services/competitorCron.ts
@@ -1,0 +1,15 @@
+import { scrapeCompetitor } from './competitorMonitor';
+
+export async function runDailyScrape(urls: string[]) {
+  const results = [];
+  for (const url of urls) {
+    try {
+      const snap = await scrapeCompetitor(url);
+      results.push(snap);
+    } catch (err) {
+      console.error('Failed to scrape', url, err);
+    }
+  }
+  return results;
+}
+

--- a/services/competitorMonitor.ts
+++ b/services/competitorMonitor.ts
@@ -1,0 +1,64 @@
+export interface CompetitorSnapshot {
+  url: string;
+  html: string;
+  pricing: string[];
+  features: string[];
+  marketingMessages: string[];
+  screenshotPath?: string;
+  capturedAt: Date;
+}
+
+export async function scrapeCompetitor(url: string): Promise<CompetitorSnapshot> {
+  const res = await fetch(url);
+  const html = await res.text();
+  const pricing = extractPricing(html);
+  const features = extractFeatures(html);
+  const marketingMessages = extractMarketing(html);
+  return {
+    url,
+    html,
+    pricing,
+    features,
+    marketingMessages,
+    capturedAt: new Date(),
+  };
+}
+
+export function detectChanges(oldSnap: CompetitorSnapshot, newSnap: CompetitorSnapshot) {
+  const changes: Record<string, unknown> = {};
+  if (JSON.stringify(oldSnap.pricing) !== JSON.stringify(newSnap.pricing)) {
+    changes.pricing = { before: oldSnap.pricing, after: newSnap.pricing };
+  }
+  if (JSON.stringify(oldSnap.features) !== JSON.stringify(newSnap.features)) {
+    changes.features = { before: oldSnap.features, after: newSnap.features };
+  }
+  if (JSON.stringify(oldSnap.marketingMessages) !== JSON.stringify(newSnap.marketingMessages)) {
+    changes.marketingMessages = {
+      before: oldSnap.marketingMessages,
+      after: newSnap.marketingMessages,
+    };
+  }
+  return changes;
+}
+
+function extractPricing(html: string): string[] {
+  const priceRegex = /\$\d+(?:\.\d{2})?/g;
+  return html.match(priceRegex) || [];
+}
+
+function extractFeatures(html: string): string[] {
+  const featureRegex = /<li[^>]*>(.*?)<\/li>/g;
+  const features: string[] = [];
+  let match;
+  // eslint-disable-next-line no-cond-assign
+  while ((match = featureRegex.exec(html))) {
+    features.push(match[1]);
+  }
+  return features;
+}
+
+function extractMarketing(html: string): string[] {
+  const headings = html.match(/<h\d[^>]*>(.*?)<\/h\d>/g) || [];
+  return headings.map((h) => h.replace(/<[^>]+>/g, ''));
+}
+

--- a/tests/competitorMonitor.test.ts
+++ b/tests/competitorMonitor.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { detectChanges } from '../services/competitorMonitor';
+
+describe('detectChanges', () => {
+  it('detects pricing changes', () => {
+    const oldSnap = {
+      url: 'https://example.com',
+      html: '',
+      pricing: ['$10'],
+      features: [],
+      marketingMessages: [],
+      capturedAt: new Date(),
+    };
+    const newSnap = { ...oldSnap, pricing: ['$15'] };
+    const changes = detectChanges(oldSnap, newSnap);
+    expect(changes.pricing).toBeDefined();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add competitor monitoring service with basic scraping and change detection
- create API routes for competitors
- add cron stub for daily scraping
- introduce UI components for competitor insights
- update competitors page to display dashboard
- add unit test for change detection

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run test` *(fails: PostCSS plugin error)*

------
https://chatgpt.com/codex/tasks/task_e_686d6ae9b80c8329b55cf40a3f05fdf2